### PR TITLE
Implement Save new optimized webpack.config in user's root, generate new stats.json using new config, fix Tab2 data chart to show real data for size change

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -800,7 +800,7 @@ ipcMain.on('install-pluggins', (event: any, arrPluginsChecked: string[]) => {
   // console.log(arrPluginsChecked)
   var exec = require('child_process').exec;
   var child;
-  
+
   parseHandler.initEntryPoints()
 
   if (arrPluginsChecked.indexOf('checkedMoment') > -1) {
@@ -991,6 +991,8 @@ function selectStatsJson() {
     return false;
   }
 
+  console.log('file[0]: ', file[0])
+
   loadStats(file[0]);
   mainWindow.webContents.send('stats-is-selected');
 }
@@ -1083,6 +1085,97 @@ function loadStats(file: string) {
     //console.log(co)
     // console.log(content.substring(0, 40))
     mainWindow.webContents.send('display-stats-reply', sunBurstData, returnObjData)
+
+    //mainWindow.webContents.send('display-stats-reply', JSON.parse(content))
+
+  });
+}
+
+export default function loadNewStats(file: string) {
+  fs.readFile(file, (err, data) => {
+    if (err) {
+      //    alert("An error ocurred updating the file" + err.message); //alert doesn't work.
+      console.log(err);
+      return;
+    }
+    // clean and send back JSON stats file
+    let content: any = data.toString();
+
+    content = content.substr(content.indexOf("{"));
+
+    //splits multiple JSON objects if more than one exists in file
+    content = content.split(/}[\n\r\s]+{/);
+
+    // repair brackets from split
+    if (content.length > 1) {
+      for (let i = 0; i < content.length; i++) {
+        content[i] = (i > 0) ? "{" : "" + content[i] + (i < content.length - 1) ? "}" : ""
+      }
+    }
+
+    content = JSON.parse(content[0])
+    while (!content.hasOwnProperty("builtAt")) {
+      content = content.children[0]
+    }
+    let returnObj: any = {};
+    returnObj.timeStamp = Date.now();
+    returnObj.time = content.time;
+    returnObj.hash = content.hash;
+    returnObj.errors = content.errors
+    returnObj.size = content.assets.reduce((size: number, asset: any): void => size + asset.size, 0)
+    returnObj.assets = content.assets.map((asset: any) => ({
+      name: asset.name,
+      chunks: asset.chunks,
+      size: asset.size,
+    }));
+
+    returnObj.chunks = content.chunks.map((chunk: any) => ({
+      size: chunk.size,
+      files: chunk.files,
+      modules: chunk.modules ?
+        chunk.modules.map((module: any) => ({
+          name: module.name,
+          size: module.size,
+          id: module.id,
+        }))
+        : [],
+    }));
+
+    let Pdata: any = []
+    Pdata.push(returnObj)
+    //loops through assets
+    let i = 0; // or the latest build
+    let path: string;
+    let sizeStr: string;
+    let sunBurstData = [];
+
+
+    for (var k = 0; k < Pdata[i].chunks.length; k++) {
+      for (var l = 0; l < Pdata[i].chunks[k].modules.length; l++) {
+        sizeStr = Pdata[i].chunks[k].modules[l].size.toString();
+        path = Pdata[i].chunks[k].modules[l].name.replace("./", "");
+        sunBurstData.push([path, sizeStr])
+      }
+    }
+    const sunBurstDataSum: number = sunBurstData.reduce((sum: number, el: any): number => {
+      return sum += parseInt(el[1])
+    }, 0)
+
+    const returnObjData = {
+      chunks: returnObj.chunks,
+      assets: returnObj.assets
+    }
+
+    let totalSize = returnObjData.chunks.reduce((totalSize, chunk) => {
+      return totalSize += chunk.size;
+    }, 0);
+
+    console.log('totalSize: ', totalSize);
+    // sunBurstData.push(returnObj);
+    // console.log(sunBurstDataSum)
+    //console.log(co)
+    // console.log(content.substring(0, 40))
+    mainWindow.webContents.send('set-new-stats', totalSize)
 
     //mainWindow.webContents.send('display-stats-reply', JSON.parse(content))
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -797,7 +797,7 @@ ipcMain.on('loadStats2', () => {
 
 ipcMain.on('install-pluggins', (event: any, arrPluginsChecked: string[]) => {
   //npm install --prefix ./install/here mini-css-extract-plugin
-  console.log(arrPluginsChecked)
+  // console.log(arrPluginsChecked)
   var exec = require('child_process').exec;
   var child;
   

--- a/src/main/parseHandler.ts
+++ b/src/main/parseHandler.ts
@@ -236,7 +236,9 @@ const parseHandler: ParseHandler = {
       if (err) throw err;
     });
 
-    fs.writeFile(this.directory + this.configFile, this.updatedConfig, (err) => {
+    console.log('checkittttt: ', this.directory)
+
+    fs.writeFile(this.directory + '/' + 'new' + this.configFile, this.updatedConfig, (err) => {
       if (err) {
         console.log(err);
         return;
@@ -261,7 +263,9 @@ const parseHandler: ParseHandler = {
 
     // console.log('this.directory: ', this.directory)
     // console.log("this.selectedConfig: ", this.selectedConfig);
-    // console.log('-----------------')
+    let testLog = "cd '" + this.directory + "' && " + this.selectedConfig;
+    let pathToSave = __dirname.replace('/dist', '') + '/assets';
+    console.log('__dirname: ', pathToSave);
 
     let aPromise = runWebpack2("cd '" + this.directory + "' && " + this.selectedConfig)
       .then((res) => {

--- a/src/main/parseHandler.ts
+++ b/src/main/parseHandler.ts
@@ -6,6 +6,7 @@ import { generate } from 'astring';
 const prettier = require("prettier");
 import { any, string } from 'prop-types';
 import { exec } from 'child_process';
+import loadNewStats from './main';
 
 interface ParseHandler {
   directory?: string,
@@ -287,9 +288,12 @@ const parseHandler: ParseHandler = {
         console.log(err);
       });
 
+    let newStats = this.directory + '/statsNew.json';
+
     if (newConfig) {
       runWebpack2("cd '" + this.directory + "' && " + newConfig)
-        .then(() => console.log('new stats generated'))
+        .then(() => console.log('got it?????', newStats))
+        .then(() => loadNewStats(newStats))
         .catch((err) => console.log(err));
     }
 

--- a/src/renderer/components/Button.tsx
+++ b/src/renderer/components/Button.tsx
@@ -7,7 +7,7 @@ interface ButtonProps {
   textContent: string;
 }
 
-const Button: React.SFC<ButtonProps> = (props) => {
+const Button = (props: ButtonProps) => {
 
   return (
     <button

--- a/src/renderer/components/D3ChartContainerCard.tsx
+++ b/src/renderer/components/D3ChartContainerCard.tsx
@@ -10,7 +10,7 @@ interface D3ChartContainerCardProps {
   displaySunburstZoom: boolean;
 }
 
-const D3ChartContainerCard: React.SFC<D3ChartContainerCardProps> = (props) => {
+const D3ChartContainerCard = (props: D3ChartContainerCardProps) => {
   return (
     <div className={props.displayChartCard ? 'whiteCard' : 'whiteCardOff'}>
       <div className="smallerMainContainer">

--- a/src/renderer/components/Home.tsx
+++ b/src/renderer/components/Home.tsx
@@ -20,6 +20,7 @@ const initialState = {
   height: 550,
   listOfConfigs: [],
   totalSizeTemp: '',
+  initialBuildSize: 0,
   totalNodeCount: 0,
   totalAssets: 0,
   totalChunks: 0,
@@ -242,7 +243,8 @@ export default class Home extends React.Component<Props, StateType> {
     let totalSize = path.datum().value;
 
     this.setState({
-      totalSizeTemp: (totalSize / 1000000).toPrecision(3) + ' Mb'
+      totalSizeTemp: (totalSize / 1000000).toPrecision(3) + ' Mb',
+      initialBuildSize: totalSize
     });
 
     function mouseover(d: any) {
@@ -869,6 +871,10 @@ export default class Home extends React.Component<Props, StateType> {
     this.props.store.setBeforeRoot(root);
   }
 
+  doSetInitialBuildSize = (): void => {
+    this.props.store.setInitialBuildSize(this.state.initialBuildSize);
+  }
+
   doSetDisplaySunburst = (): void => {
     this.props.store.setDisplaySunburst();
     if (!this.props.store.totalSizeTemp) {
@@ -878,6 +884,7 @@ export default class Home extends React.Component<Props, StateType> {
         this.state.totalAssets,
         this.state.totalChunks
       );
+      this.doSetInitialBuildSize();
     }
   }
 

--- a/src/renderer/components/HomeHeadingBox.tsx
+++ b/src/renderer/components/HomeHeadingBox.tsx
@@ -6,7 +6,7 @@ interface HeadingBoxProps {
   displayData?: number;
 }
 
-const HomeHeadingBox: React.SFC<HeadingBoxProps> = (props) => {
+const HomeHeadingBox = (props: HeadingBoxProps) => {
   return (
     <div className="chartStatsHeadingBox">
       <div className='boxTextContainer'>

--- a/src/renderer/components/TabTwo.tsx
+++ b/src/renderer/components/TabTwo.tsx
@@ -80,11 +80,11 @@ export default class TabTwo extends React.Component<Props, StateType> {
   installPluggins = (): void => {
     const arr_plugins: string[] = ['checkedMini', 'checkedSplitChunks', 'checkedMoment'];
     let arrToInstall: string[] = arr_plugins.reduce((accum: string[], el: string): string[] => {
-      console.log(el)
+      // console.log(el)
       if (this.state[el] === true) accum.push(el);
       return accum;
     }, [])
-    console.log(arrToInstall)
+    // console.log(arrToInstall)
     ipcRenderer.send('install-pluggins', arrToInstall);
     this.doSetIsNewConfigGenerated();
   }
@@ -94,9 +94,9 @@ export default class TabTwo extends React.Component<Props, StateType> {
   }
 
   saveConfig = (): void => {
-    this.installPluggins
-    let temp = this.state.value
-    ipcRenderer.send('save-config', this.state.value)
+    this.installPluggins;
+    let temp = this.state.value;
+    ipcRenderer.send('save-config', this.state.value);
   }
 
   handleChangeCheckboxMini = (event: any): void => {

--- a/src/renderer/components/TabTwo.tsx
+++ b/src/renderer/components/TabTwo.tsx
@@ -15,7 +15,8 @@ const initialState = {
   checkedMini: false,
   checkedSplitChunks: false,
   checkedMoment: false,
-  value: ""
+  value: "",
+  newTotalSize: 0
 }
 
 type StateType = Readonly<typeof initialState>
@@ -39,6 +40,11 @@ export default class TabTwo extends React.Component<Props, StateType> {
     ipcRenderer.on('display-config', (event: any, data: any): void => {
       console.log("display updated config")
       this.setState({ value: data });
+    });
+
+    ipcRenderer.on('set-new-stats', (event: any, data: number): void => {
+      console.log('data: ', data);
+      this.setState({ newTotalSize: data });
     })
 
   }
@@ -46,7 +52,7 @@ export default class TabTwo extends React.Component<Props, StateType> {
   drawProgressChart = (): void => {
     this.doSelectOptimization();
     setTimeout(() => {
-      var data = [this.props.store.beforeTotalSize, this.props.store.afterTotalSize]; // here are the data values; v1 = total, v2 = current value
+      var data = [this.props.store.initialBuildSize, this.state.newTotalSize]; // here are the data values; v1 = total, v2 = current value
 
       var chart = d3.select("#progressChartContainer").append("svg") // creating the svg object inside the container div
         .attr("class", "progressChart")
@@ -150,6 +156,8 @@ export default class TabTwo extends React.Component<Props, StateType> {
           <WhiteCardTabTwoOptimizationDisplay
             beforeTotalSize={store.beforeTotalSize}
             afterTotalSize={store.afterTotalSize}
+            initialBuildSize={store.initialBuildSize}
+            newBuildSize={this.state.newTotalSize}
           />
         }
       </div >

--- a/src/renderer/components/WhiteCardPackageJSON.tsx
+++ b/src/renderer/components/WhiteCardPackageJSON.tsx
@@ -6,7 +6,7 @@ interface WhiteCardPackageJSONProps {
   getPackageJson(): void;
 }
 
-const WhiteCardPackageJSON: React.SFC<WhiteCardPackageJSONProps> = (props) => {
+const WhiteCardPackageJSON = (props: WhiteCardPackageJSONProps) => {
   return (
     <div className='whiteCard' >
       {!props.isPackageSelected &&

--- a/src/renderer/components/WhiteCardStatsJSON.tsx
+++ b/src/renderer/components/WhiteCardStatsJSON.tsx
@@ -8,7 +8,7 @@ interface WhiteCardStatsJSONProps {
   generateStatsFile(): void;
 }
 
-const WhiteCardStatsJSON: React.SFC<WhiteCardStatsJSONProps> = (props) => {
+const WhiteCardStatsJSON = (props: WhiteCardStatsJSONProps) => {
   return (
     <div className="whiteCard">
       <div id="stats-file-selector">

--- a/src/renderer/components/WhiteCardTabThreeBuildConfig.tsx
+++ b/src/renderer/components/WhiteCardTabThreeBuildConfig.tsx
@@ -18,7 +18,7 @@ interface WhiteCardTabThreeBuildConfigProps {
   defaultFormattedCode: string;
 }
 
-const WhiteCardTabThreeBuildConfig: React.SFC<WhiteCardTabThreeBuildConfigProps> = (props) => {
+const WhiteCardTabThreeBuildConfig = (props: WhiteCardTabThreeBuildConfigProps) => {
   return (
     <div className="whiteCard">
       <div className="tabTwo-ThreeHeading" >Select your features</div>

--- a/src/renderer/components/WhiteCardTabThreeSelectRoot.tsx
+++ b/src/renderer/components/WhiteCardTabThreeSelectRoot.tsx
@@ -5,7 +5,7 @@ interface WhiteCardTabThreeSelectRootProps {
   selectCustomWebConfigRoot(event: any): void;
 }
 
-const WhiteCardTabThreeSelectRoot: React.SFC<WhiteCardTabThreeSelectRootProps> = (props) => {
+const WhiteCardTabThreeSelectRoot = (props: WhiteCardTabThreeSelectRootProps) => {
   return (
     <div className="whiteCard">
       <div className="tabTwo-ThreeHeading">Select your root directory</div>

--- a/src/renderer/components/WhiteCardTabThreeWelcome.tsx
+++ b/src/renderer/components/WhiteCardTabThreeWelcome.tsx
@@ -4,7 +4,7 @@ interface WhiteCardTabThreeWelcomeProps {
   isRootSelected: boolean;
 }
 
-const WhiteCardTabThreeWelcome: React.SFC<WhiteCardTabThreeWelcomeProps> = (props) => {
+const WhiteCardTabThreeWelcome = (props: WhiteCardTabThreeWelcomeProps) => {
   return (
     <div className="whiteCard welcomeCard">
       <div id="welcomeHeaderTabThree">Build Customized Webpack.config File</div>

--- a/src/renderer/components/WhiteCardTabTwoGreenCheck.tsx
+++ b/src/renderer/components/WhiteCardTabTwoGreenCheck.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FaCheck } from "react-icons/fa";
 
-const WhiteCardTabTwoGreenCheck: React.SFC<{}> = () => {
+const WhiteCardTabTwoGreenCheck = () => {
   return (
     <div className="whiteCard">
       <div className="tabTwo-ThreeHeading">

--- a/src/renderer/components/WhiteCardTabTwoMain.tsx
+++ b/src/renderer/components/WhiteCardTabTwoMain.tsx
@@ -13,7 +13,7 @@ interface WhiteCardTabTwoMainProps {
   drawProgressChart(): void;
 }
 
-const WhiteCardTabTwoMain: React.SFC<WhiteCardTabTwoMainProps> = (props) => {
+const WhiteCardTabTwoMain = (props: WhiteCardTabTwoMainProps) => {
   return (
     <div className="whiteCard">
       <div className="tabTwo-ThreeHeading">Optimization Plugins</div>

--- a/src/renderer/components/WhiteCardTabTwoOptimizationDisplay.tsx
+++ b/src/renderer/components/WhiteCardTabTwoOptimizationDisplay.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 interface WhiteCardTabTwoOptimizationDisplayProps {
   beforeTotalSize: number;
   afterTotalSize: number;
+  initialBuildSize: number;
+  newBuildSize: number;
 }
 
 const WhiteCardTabTwoOptimizationDisplay = (props: WhiteCardTabTwoOptimizationDisplayProps) => {
@@ -11,10 +13,10 @@ const WhiteCardTabTwoOptimizationDisplay = (props: WhiteCardTabTwoOptimizationDi
       <div className="tabTwo-ThreeHeading">View bundle optimization below:</div>
       <div id='progressChartContainer'></div>
       <div className="lineBreak"></div>
-      <div className="tabTwoInfoText">Size before optimization: <span className="dataFont">{(props.beforeTotalSize / 1000000).toPrecision(3)} Mb </span></div>
-      <div className="tabTwoInfoText">Size after optimization: <span className="dataFont">{(props.afterTotalSize / 1000000).toPrecision(3)} Mb</span></div>
-      <div className="tabTwoInfoText">Size reduction: <span className="dataFont">{((props.beforeTotalSize - props.afterTotalSize) / 1000000).toPrecision(3)} Mb</span></div>
-      <div className="tabTwoInfoText">Percentage reduction: <span className="dataFont">{((((props.beforeTotalSize - props.afterTotalSize) / props.beforeTotalSize)) * 100).toPrecision(3)}%</span></div>
+      <div className="tabTwoInfoText">Size before optimization: <span className="dataFont">{(props.initialBuildSize / 1000000).toPrecision(3)} Mb </span></div>
+      <div className="tabTwoInfoText">Size after optimization: <span className="dataFont">{(props.newBuildSize / 1000000).toPrecision(3)} Mb</span></div>
+      <div className="tabTwoInfoText">Size reduction: <span className="dataFont">{((props.initialBuildSize - props.newBuildSize) / 1000000).toPrecision(3)} Mb</span></div>
+      <div className="tabTwoInfoText">Percentage reduction: <span className="dataFont">{((((props.initialBuildSize - props.newBuildSize) / props.initialBuildSize)) * 100).toPrecision(3)}%</span></div>
     </div>
   );
 }

--- a/src/renderer/components/WhiteCardTabTwoOptimizationDisplay.tsx
+++ b/src/renderer/components/WhiteCardTabTwoOptimizationDisplay.tsx
@@ -5,7 +5,7 @@ interface WhiteCardTabTwoOptimizationDisplayProps {
   afterTotalSize: number;
 }
 
-const WhiteCardTabTwoOptimizationDisplay: React.SFC<WhiteCardTabTwoOptimizationDisplayProps> = (props) => {
+const WhiteCardTabTwoOptimizationDisplay = (props: WhiteCardTabTwoOptimizationDisplayProps) => {
   return (
     <div className="whiteCard">
       <div className="tabTwo-ThreeHeading">View bundle optimization below:</div>

--- a/src/renderer/components/WhiteCardWebpackConfig.tsx
+++ b/src/renderer/components/WhiteCardWebpackConfig.tsx
@@ -5,7 +5,7 @@ interface WhiteCardWebpackConfigProps {
   getWebpackConfig(event: any): void;
 }
 
-const WhiteCardWebpackConfig: React.SFC<WhiteCardWebpackConfigProps> = (props) => {
+const WhiteCardWebpackConfig = (props: WhiteCardWebpackConfigProps) => {
   return (
     <div className="whiteCard">
       <div id="webpack-config-selector">

--- a/src/renderer/components/WhiteCardWelcome.tsx
+++ b/src/renderer/components/WhiteCardWelcome.tsx
@@ -5,7 +5,7 @@ interface WhiteCardWelcomeProps {
   isPackageSelected: boolean;
 }
 
-const WhiteCardWelcome: React.SFC<WhiteCardWelcomeProps> = (props) => {
+const WhiteCardWelcome = (props: WhiteCardWelcomeProps) => {
   return (
     <div className={props.displayWelcomeCard ? 'whiteCard welcomeCard' : 'displayOff'} >
       <div id="welcomeHeader">Welcome to WebpackOps</div>

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -1,4 +1,5 @@
 import { observable, action } from 'mobx'
+import { initializeInstance } from 'mobx/lib/internal';
 
 export type StoreType = {
 	name: string,
@@ -15,6 +16,8 @@ export type StoreType = {
 	totalChunks: number,
 	setIsLoadingTrue(): void,
 	setRootSelected(): void,
+	initialBuildSize: number,
+	setInitialBuildSize(input: number): void,
 	displaySunburst: boolean,
 	displaySunburstZoom: boolean,
 	displayTreemap: boolean,
@@ -155,6 +158,9 @@ export default class Store {
 	afterTotalSize = 999999;
 
 	@observable
+	initialBuildSize = 0;
+
+	@observable
 	totalSize = 1334337;
 
 	@observable
@@ -234,6 +240,11 @@ export default class Store {
 	setIsLoadingTrue() {
 		this.isLoading = true;
 		this.displaySelectJson = false;
+	}
+
+	@action.bound
+	setInitialBuildSize(input: number) {
+		this.initialBuildSize = input;
 	}
 
 	@action.bound


### PR DESCRIPTION
- get Tab2 size change chart to accurately show size change between original build and new build
- make creation of new webpack.config on Tab2 asynchronous, implement generation of new stats.json upon resolution of new webpack.config saving
- fix save new webpack.config to now save to user's root directory of project instead of to desktop
- refactor all stateless functional components to have cleaner, more minimal Typescript syntax