### PR TITLE
Save all builds by date/time in WebpackOpsAssets dir, conditional rendering on modal, add modal on Home

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -72,8 +72,7 @@ ipcMain.on('saveCustomConfig', (event: any, rootDirectoryCustomConfig: string) =
       return;
     }
   });
-})
-
+});
 
 ipcMain.on('selectCustomWebConfig', (event: any, arg: any) => {
   let customDirectory: string = dialog.showOpenDialog({ properties: ['openDirectory'] })[0]

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -27,7 +27,7 @@ function createWindow() {
     })
   );
 
-  // Open the DevTools.
+  // Uncomment to open the DevTools.
   // mainWindow.webContents.openDevTools();
 
   // Emitted when the window is closed.
@@ -66,7 +66,6 @@ app.on('activate', () => {
  *********************************************/
 ipcMain.on('saveCustomConfig', (event: any, rootDirectoryCustomConfig: string) => {
 
-
   fs.writeFile(rootDirectoryCustomConfig + '/webpack.config.js', formattedCode1ToSave, (err) => {
     if (err) {
       console.log(err);
@@ -83,12 +82,11 @@ ipcMain.on('selectCustomWebConfig', (event: any, arg: any) => {
   let customDirectory: string = dialog.showOpenDialog({ properties: ['openDirectory'] })[0]
 
   if (!customDirectory) {
-    console.log('no gooo');
     return false;
   }
   mainWindow.webContents.send('root-is-selected');
 
-  mainWindow.webContents.send('customRootDirectrySet', customDirectory)
+  mainWindow.webContents.send('customRootDirectrySet', customDirectory);
 });
 
 let customAST: any = {};
@@ -116,13 +114,11 @@ ipcMain.on('CustomAST', (event: any, arg: any) => {
     customAST = astCustomConfig;
     const formattedCode1 = generate(customAST, {
       comments: true,
-    })
-    console.log(formattedCode1)
-    console.log(typeof formattedCode1)
-    formattedCode1ToSave = formattedCode1
+    });
 
+    formattedCode1ToSave = formattedCode1;
 
-    mainWindow.webContents.send('transferCustomAST', formattedCode1)
+    mainWindow.webContents.send('transferCustomAST', formattedCode1);
   });
 })
 
@@ -134,40 +130,21 @@ ipcMain.on('addReactToAST', (event: any, arg: any) => {
       locations: true,
       // onComment: comments,
     });
-    console.log('react')
-    console.log('read' + JSON.stringify(ReactAST.body[0].expression.right.properties))
-    // module: ReactAST.body[0].expression.right.properties[0]
-    // resolve: ReactAST.body[0].expression.right.properties[0]
-    // devServer: ReactAST.body[0].expression.right.properties[0]
-    console.log('AST')
-    let customASTPropertyKey: string[] = []
-    let ReactASTPropertyKey: string[] = ["module", "resolve", "devServer"]
-    //customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) =>{
-    //  customASTPropertyKey.push(el.key.name)
 
-    //})
-    //console.log(customASTPropertyKey);
+    let customASTPropertyKey: string[] = [];
+    let ReactASTPropertyKey: string[] = ["module", "resolve", "devServer"];
 
     if (numberOfRules === 0) {
       customAST.body[customAST.body.length - 1].expression.right.properties.push(ReactAST.body[0].expression.right.properties[0]);
       moduleExist = true;
       numberOfRules += 1;
     } else {
-      console.log('hi1')
       customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el, i) => {
         if (el.key.name === "module") {
-          console.log('hi2')
-          let moduleArr = el.value.properties
-          console.log('hi3')
-
+          let moduleArr = el.value.properties;
           moduleArr.forEach((moduleEl) => {
             if (moduleEl.key.name === "rules") {
-              console.log('here')
-              console.log(JSON.stringify(moduleEl.value.elements))
-              console.log(JSON.stringify(ReactAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]))
-
-              moduleEl.value.elements.unshift(ReactAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0])
-              console.log(JSON.stringify(moduleEl.value.elements))
+              moduleEl.value.elements.unshift(ReactAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]);
             }
           });
         }
@@ -177,47 +154,39 @@ ipcMain.on('addReactToAST', (event: any, arg: any) => {
     }
 
     if (customASTPropertyKey.indexOf("resolve") === -1) {
-      customAST.body[customAST.body.length - 1].expression.right.properties.push(ReactAST.body[0].expression.right.properties[1])
+      customAST.body[customAST.body.length - 1].expression.right.properties.push(ReactAST.body[0].expression.right.properties[1]);
     }
 
     if (customASTPropertyKey.indexOf("devServer") === -1) {
-      customAST.body[customAST.body.length - 1].expression.right.properties.push(ReactAST.body[0].expression.right.properties[2])
+      customAST.body[customAST.body.length - 1].expression.right.properties.push(ReactAST.body[0].expression.right.properties[2]);
     }
 
-    console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
     const formattedCode1 = generate(customAST, {
       comments: true,
     })
-    console.log(formattedCode1)
-    formattedCode1ToSave = formattedCode1
-    mainWindow.webContents.send('transferCustomAST', formattedCode1)
+
+    formattedCode1ToSave = formattedCode1;
+    mainWindow.webContents.send('transferCustomAST', formattedCode1);
   })
 })
 
 ipcMain.on('removeReactToAST', (event: any, arg: any) => {
-  console.log(moduleExist)
-  console.log(numberOfRules)
 
   let module_index = 0;
   let resolve_index = 0;
   let devServer_index = 0;
   for (let i = 0; i < customAST.body[customAST.body.length - 1].expression.right.properties.length; i += 1) {
-    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i
+    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i;
   }
-  console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
 
   if (numberOfRules === 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    console.log('just than 1')
-
     customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1)
     numberOfRules -= 1;
   } else if (numberOfRules > 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    console.log('more than 1')
     for (let j = 0; j < customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.length; j += 1) {
-      console.log(typeof customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw)
+
       if (customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw.includes("js|jsx")) {
-        //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0]))
-        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1)
+        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1);
         numberOfRules -= 1;
       }
     }
@@ -227,200 +196,159 @@ ipcMain.on('removeReactToAST', (event: any, arg: any) => {
     if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "resolve") { console.log('hi'); resolve_index = i }
   }
   if (!typescriptSelected) {
-    customAST.body[customAST.body.length - 1].expression.right.properties.splice(resolve_index, 1)
+    customAST.body[customAST.body.length - 1].expression.right.properties.splice(resolve_index, 1);
   } //insert logic to remove typescript
 
   for (let i = 0; i < customAST.body[customAST.body.length - 1].expression.right.properties.length; i += 1) {
-    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "devServer") devServer_index = i
+    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "devServer") devServer_index = i;
   }
 
   customAST.body[customAST.body.length - 1].expression.right.properties.splice(devServer_index, 1)
   const formattedCode1 = generate(customAST, {
     comments: true,
   })
-  formattedCode1ToSave = formattedCode1
+  formattedCode1ToSave = formattedCode1;
 
-  console.log(formattedCode1)
-  mainWindow.webContents.send('transferCustomAST', formattedCode1)
-
-})
+  mainWindow.webContents.send('transferCustomAST', formattedCode1);
+});
 
 ipcMain.on('addCSSToAST', (event: any, arg: any) => {
-  console.log('hi')
-
   fs.readFile(__dirname + '/../src/src_custom_config/CSS.config.js', (err, data) => {
     if (err) return console.log(err);
-    console.log('hi')
     CSSAST = acorn.parse(data.toString(), {
       ecmaVersion: 6,
       locations: true,
       // onComment: comments,
     });
-    console.log('CSS')
-    console.log('read' + JSON.stringify(CSSAST.body[0].expression.right.properties[0]))
-    console.log('AST')
     let customASTPropertyKey: string[] = []
     customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
-      customASTPropertyKey.push(el.key.name)
-
-    })
-    console.log(customASTPropertyKey);
-    //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
+      customASTPropertyKey.push(el.key.name);
+    });
 
     if (customASTPropertyKey.indexOf(CSSAST.body[0].expression.right.properties[0].key.name) === -1) {
-      console.log('hi2')
-      customAST.body[customAST.body.length - 1].expression.right.properties.push(CSSAST.body[0].expression.right.properties[0])
+      customAST.body[customAST.body.length - 1].expression.right.properties.push(CSSAST.body[0].expression.right.properties[0]);
       moduleExist = true;
       numberOfRules += 1;
     } else {
-      console.log('hi1')
       let customASTModulePropertyKey: string[] = [];
+
       customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
         if (el.key.name === "module") {
-          let moduleArr = el.value.properties
+          let moduleArr = el.value.properties;
           moduleArr.forEach((moduleEl) => {
             if (moduleEl.key.name === "rules") {
-              console.log('here')
-              console.log(JSON.stringify(moduleEl.value.elements))
-              console.log(JSON.stringify(CSSAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]))
-              moduleEl.value.elements.push(CSSAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0])
+              moduleEl.value.elements.push(CSSAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]);
             }
-          })
+          });
         }
-      })
+      });
+
       moduleExist = true;
       numberOfRules += 1;
     }
 
-    console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
     const formattedCode1 = generate(customAST, {
       comments: true,
-    })
-    formattedCode1ToSave = formattedCode1
-    console.log(formattedCode1)
-    mainWindow.webContents.send('transferCustomAST', formattedCode1)
-  })
-})
+    });
+
+    formattedCode1ToSave = formattedCode1;
+    mainWindow.webContents.send('transferCustomAST', formattedCode1);
+  });
+});
 
 ipcMain.on('removeCSSToAST', (event: any, arg: any) => {
-  console.log(moduleExist)
-  console.log(numberOfRules)
-
   let module_index = 0;
   for (let i = 0; i < customAST.body[customAST.body.length - 1].expression.right.properties.length; i += 1) {
-    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i
+    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i;
   }
-  console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
 
   if (numberOfRules === 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    console.log('just than 1')
-
-    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1)
+    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1);
     numberOfRules -= 1;
   } else if (numberOfRules > 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    console.log('more than 1')
     for (let j = 0; j < customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.length; j += 1) {
-      console.log(typeof customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw)
       if (customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw.includes(".css")) {
-        //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0]))
-        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1)
+        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1);
         numberOfRules -= 1;
       }
     }
   }
   const formattedCode1 = generate(customAST, {
     comments: true,
-  })
-  formattedCode1ToSave = formattedCode1
-  console.log(formattedCode1)
-  mainWindow.webContents.send('transferCustomAST', formattedCode1)
+  });
 
-})
+  formattedCode1ToSave = formattedCode1;
+  mainWindow.webContents.send('transferCustomAST', formattedCode1);
+});
 
 ipcMain.on('addSassToAST', (event: any, arg: any) => {
-  console.log('hi')
-
   fs.readFile(__dirname + '/../src/src_custom_config/Sass.config.js', (err, data) => {
     if (err) return console.log(err);
-    console.log('hi')
     SassAST = acorn.parse(data.toString(), {
       ecmaVersion: 6,
       locations: true,
       // onComment: comments,
     });
-    console.log('Sass')
-    console.log('read' + JSON.stringify(SassAST.body[0].expression.right.properties[0]))
-    console.log('AST')
+
     let customASTPropertyKey: string[] = []
     customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
-      customASTPropertyKey.push(el.key.name)
-    })
-    console.log(customASTPropertyKey);
-    //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
+      customASTPropertyKey.push(el.key.name);
+    });
 
     if (customASTPropertyKey.indexOf(SassAST.body[0].expression.right.properties[0].key.name) === -1) {
       moduleExist = true;
       numberOfRules += 1;
-      customAST.body[customAST.body.length - 1].expression.right.properties.push(SassAST.body[0].expression.right.properties[0])
+      customAST.body[customAST.body.length - 1].expression.right.properties.push(SassAST.body[0].expression.right.properties[0]);
     } else {
-      console.log('hi1')
       let customASTModulePropertyKey: string[] = [];
       customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
         if (el.key.name === "module") {
-          let moduleArr = el.value.properties
+          let moduleArr = el.value.properties;
           moduleArr.forEach((moduleEl) => {
             if (moduleEl.key.name === "rules") {
-              console.log('here')
-              console.log(JSON.stringify(moduleEl.value.elements))
-              console.log(JSON.stringify(SassAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]))
-              moduleEl.value.elements.push(SassAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0])
+              moduleEl.value.elements.push(SassAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]);
             }
-          })
+          });
         }
-      })
+      });
+
       moduleExist = true;
       numberOfRules += 1;
     }
 
-    console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
     const formattedCode1 = generate(customAST, {
       comments: true,
-    })
-    formattedCode1ToSave = formattedCode1
-    console.log(formattedCode1)
-    mainWindow.webContents.send('transferCustomAST', formattedCode1)
-  })
-})
+    });
+
+    formattedCode1ToSave = formattedCode1;
+    mainWindow.webContents.send('transferCustomAST', formattedCode1);
+  });
+});
 
 ipcMain.on('removeSassToAST', (event: any, arg: any) => {
   let module_index = 0;
   for (let i = 0; i < customAST.body[customAST.body.length - 1].expression.right.properties.length; i += 1) {
-    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i
+    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i;
   }
-  console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
 
   if (numberOfRules === 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    console.log('just than 1')
 
-    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1)
+    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1);
     numberOfRules -= 1;
   } else if (numberOfRules > 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    console.log('more than 1')
     for (let j = 0; j < customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.length; j += 1) {
-      console.log(typeof customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw)
       if (customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw.includes(".scss")) {
-        //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0]))
-        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1)
+        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1);
         numberOfRules -= 1;
       }
     }
   }
   const formattedCode1 = generate(customAST, {
     comments: true,
-  })
-  formattedCode1ToSave = formattedCode1
-  console.log(formattedCode1)
-  mainWindow.webContents.send('transferCustomAST', formattedCode1)
+  });
+
+  formattedCode1ToSave = formattedCode1;
+  mainWindow.webContents.send('transferCustomAST', formattedCode1);
 });
 
 
@@ -439,64 +367,51 @@ ipcMain.on('addLessToAST', (event: any, arg: any) => {
     let customASTPropertyKey: string[] = [];
     customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
       customASTPropertyKey.push(el.key.name);
-    })
-    console.log(customASTPropertyKey);
-
+    });
 
     if (customASTPropertyKey.indexOf(LessAST.body[0].expression.right.properties[0].key.name) === -1) {
       moduleExist = true;
       numberOfRules += 1;
-      console.log('hi2')
-      customAST.body[customAST.body.length - 1].expression.right.properties.push(LessAST.body[0].expression.right.properties[0])
+      customAST.body[customAST.body.length - 1].expression.right.properties.push(LessAST.body[0].expression.right.properties[0]);
     } else {
-      console.log('hi1')
       let customASTModulePropertyKey: string[] = [];
       customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
         if (el.key.name === "module") {
           let moduleArr = el.value.properties;
           moduleArr.forEach((moduleEl) => {
             if (moduleEl.key.name === "rules") {
-              console.log('here')
-              console.log(JSON.stringify(moduleEl.value.elements))
-              console.log(JSON.stringify(LessAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]))
-              moduleEl.value.elements.push(LessAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0])
+              moduleEl.value.elements.push(LessAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]);
             }
-          })
+          });
         }
-      })
+      });
+
       moduleExist = true;
       numberOfRules += 1;
     }
 
-    console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
     const formattedCode1 = generate(customAST, {
       comments: true,
-    })
-    formattedCode1ToSave = formattedCode1
-    console.log(formattedCode1)
-    mainWindow.webContents.send('transferCustomAST', formattedCode1)
+    });
+
+    formattedCode1ToSave = formattedCode1;
+    mainWindow.webContents.send('transferCustomAST', formattedCode1);
   });
 });
 
 ipcMain.on('removeLessToAST', (event: any, arg: any) => {
   let module_index = 0;
   for (let i = 0; i < customAST.body[customAST.body.length - 1].expression.right.properties.length; i += 1) {
-    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i
+    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i;
   }
-  console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
 
   if (numberOfRules === 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    console.log('just than 1')
-
-    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1)
+    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1);
     numberOfRules -= 1;
   } else if (numberOfRules > 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    console.log('more than 1')
     for (let j = 0; j < customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.length; j += 1) {
-      console.log(typeof customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw)
       if (customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw.includes(".less")) {
-        //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0]))
-        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1)
+        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1);
         numberOfRules -= 1;
       }
     }
@@ -504,172 +419,66 @@ ipcMain.on('removeLessToAST', (event: any, arg: any) => {
 
   const formattedCode1 = generate(customAST, {
     comments: true,
-  })
-  formattedCode1ToSave = formattedCode1
+  });
 
-  console.log(formattedCode1)
-  mainWindow.webContents.send('transferCustomAST', formattedCode1)
-})
+  formattedCode1ToSave = formattedCode1;
+  mainWindow.webContents.send('transferCustomAST', formattedCode1);
+});
 
 ipcMain.on('addStylusToAST', (event: any, arg: any) => {
-  console.log('hi')
-
   fs.readFile(__dirname + '/../src/src_custom_config/stylus.config.js', (err, data) => {
     if (err) return console.log(err);
-    console.log('hi')
     stylusAST = acorn.parse(data.toString(), {
       ecmaVersion: 6,
       locations: true,
       // onComment: comments,
     });
-    console.log('Stylus')
-    console.log('read' + JSON.stringify(stylusAST.body[0].expression.right.properties[0]))
-    console.log('AST')
     let customASTPropertyKey: string[] = []
     customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
-      customASTPropertyKey.push(el.key.name)
-    })
-    console.log(customASTPropertyKey);
-    //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
+      customASTPropertyKey.push(el.key.name);
+    });
 
     if (customASTPropertyKey.indexOf(stylusAST.body[0].expression.right.properties[0].key.name) === -1) {
       moduleExist = true;
       numberOfRules += 1;
-      console.log('hi2')
-      customAST.body[customAST.body.length - 1].expression.right.properties.push(stylusAST.body[0].expression.right.properties[0])
+      customAST.body[customAST.body.length - 1].expression.right.properties.push(stylusAST.body[0].expression.right.properties[0]);
     } else {
-      console.log('hi1')
       let customASTModulePropertyKey: string[] = [];
       customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
         if (el.key.name === "module") {
-          let moduleArr = el.value.properties
+          let moduleArr = el.value.properties;
           moduleArr.forEach((moduleEl) => {
             if (moduleEl.key.name === "rules") {
-              console.log('here')
-              console.log(JSON.stringify(moduleEl.value.elements))
-              console.log(JSON.stringify(stylusAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]))
-              moduleEl.value.elements.push(stylusAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0])
+              moduleEl.value.elements.push(stylusAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]);
             }
-          })
+          });
         }
-      })
+      });
       moduleExist = true;
       numberOfRules += 1;
     }
 
-    console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
     const formattedCode1 = generate(customAST, {
       comments: true,
-    })
-    formattedCode1ToSave = formattedCode1
+    });
 
-    console.log(formattedCode1)
-    mainWindow.webContents.send('transferCustomAST', formattedCode1)
-  })
-})
+    formattedCode1ToSave = formattedCode1;
+    mainWindow.webContents.send('transferCustomAST', formattedCode1);
+  });
+});
 
 ipcMain.on('removeStylusToAST', (event: any, arg: any) => {
   let module_index = 0;
   for (let i = 0; i < customAST.body[customAST.body.length - 1].expression.right.properties.length; i += 1) {
-    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i
+    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i;
   }
-  console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
 
   if (numberOfRules === 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    console.log('just than 1')
-
-    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1)
+    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1);
     numberOfRules -= 1;
   } else if (numberOfRules > 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
     for (let j = 0; j < customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.length; j += 1) {
       if (customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw.includes(".styl")) {
-        //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0]))
-        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1)
-        numberOfRules -= 1;
-      }
-    }
-  }
-  const formattedCode1 = generate(customAST, {
-    comments: true,
-  })
-  formattedCode1ToSave = formattedCode1
-
-  console.log(formattedCode1)
-  mainWindow.webContents.send('transferCustomAST', formattedCode1)
-})
-
-ipcMain.on('addSVGToAST', (event: any, arg: any) => {
-  console.log('hi')
-
-  fs.readFile(__dirname + '/../src/src_custom_config/svg.config.js', (err, data) => {
-    if (err) return console.log(err);
-    console.log('hi')
-    svgAST = acorn.parse(data.toString(), {
-      ecmaVersion: 6,
-      locations: true,
-      // onComment: comments,
-    });
-    console.log('SVG')
-    console.log('read' + JSON.stringify(svgAST.body[0].expression.right.properties[0]))
-    console.log('AST')
-    let customASTPropertyKey: string[] = []
-    customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
-      customASTPropertyKey.push(el.key.name)
-    })
-    console.log(customASTPropertyKey);
-    //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
-
-    if (customASTPropertyKey.indexOf(svgAST.body[0].expression.right.properties[0].key.name) === -1) {
-      moduleExist = true;
-      numberOfRules += 1;
-      console.log('hi2')
-      customAST.body[customAST.body.length - 1].expression.right.properties.push(svgAST.body[0].expression.right.properties[0])
-    } else {
-      console.log('hi1')
-      let customASTModulePropertyKey: string[] = [];
-      customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
-        if (el.key.name === "module") {
-          let moduleArr = el.value.properties
-          moduleArr.forEach((moduleEl) => {
-            if (moduleEl.key.name === "rules") {
-              console.log('here')
-              console.log(JSON.stringify(moduleEl.value.elements))
-              console.log(JSON.stringify(svgAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]))
-              moduleEl.value.elements.push(svgAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0])
-            }
-          })
-        }
-      })
-      moduleExist = true;
-      numberOfRules += 1;
-    }
-
-    console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
-    const formattedCode1 = generate(customAST, {
-      comments: true,
-    })
-    console.log(formattedCode1)
-    formattedCode1ToSave = formattedCode1
-
-    mainWindow.webContents.send('transferCustomAST', formattedCode1)
-  })
-})
-
-ipcMain.on('removeSVGToAST', (event: any, arg: any) => {
-  let module_index = 0;
-  for (let i = 0; i < customAST.body[customAST.body.length - 1].expression.right.properties.length; i += 1) {
-    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i
-  }
-  console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
-
-  if (numberOfRules === 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    console.log('just than 1')
-    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1)
-    numberOfRules -= 1;
-  } else if (numberOfRules > 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-
-    for (let j = 0; j < customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.length; j += 1) {
-      if (customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw.includes(".svg")) {
         customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1);
         numberOfRules -= 1;
       }
@@ -679,10 +488,77 @@ ipcMain.on('removeSVGToAST', (event: any, arg: any) => {
     comments: true,
   });
 
-  formattedCode1ToSave = formattedCode1
+  formattedCode1ToSave = formattedCode1;
+  mainWindow.webContents.send('transferCustomAST', formattedCode1);
+});
 
-  mainWindow.webContents.send('transferCustomAST', formattedCode1)
-})
+ipcMain.on('addSVGToAST', (event: any, arg: any) => {
+  fs.readFile(__dirname + '/../src/src_custom_config/svg.config.js', (err, data) => {
+    if (err) return console.log(err);
+    svgAST = acorn.parse(data.toString(), {
+      ecmaVersion: 6,
+      locations: true,
+      // onComment: comments,
+    });
+    let customASTPropertyKey: string[] = []
+    customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
+      customASTPropertyKey.push(el.key.name);
+    })
+
+    if (customASTPropertyKey.indexOf(svgAST.body[0].expression.right.properties[0].key.name) === -1) {
+      moduleExist = true;
+      numberOfRules += 1;
+      customAST.body[customAST.body.length - 1].expression.right.properties.push(svgAST.body[0].expression.right.properties[0]);
+    } else {
+      let customASTModulePropertyKey: string[] = [];
+      customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
+        if (el.key.name === "module") {
+          let moduleArr = el.value.properties;
+          moduleArr.forEach((moduleEl) => {
+            if (moduleEl.key.name === "rules") {
+              moduleEl.value.elements.push(svgAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]);
+            }
+          });
+        }
+      });
+      moduleExist = true;
+      numberOfRules += 1;
+    }
+
+    const formattedCode1 = generate(customAST, {
+      comments: true,
+    });
+
+    formattedCode1ToSave = formattedCode1;
+    mainWindow.webContents.send('transferCustomAST', formattedCode1);
+  });
+});
+
+ipcMain.on('removeSVGToAST', (event: any, arg: any) => {
+  let module_index = 0;
+  for (let i = 0; i < customAST.body[customAST.body.length - 1].expression.right.properties.length; i += 1) {
+    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i;
+  }
+
+  if (numberOfRules === 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
+    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1);
+    numberOfRules -= 1;
+  } else if (numberOfRules > 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
+    for (let j = 0; j < customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.length; j += 1) {
+      if (customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw.includes(".svg")) {
+        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1);
+        numberOfRules -= 1;
+      }
+    }
+  }
+
+  const formattedCode1 = generate(customAST, {
+    comments: true,
+  });
+
+  formattedCode1ToSave = formattedCode1;
+  mainWindow.webContents.send('transferCustomAST', formattedCode1);
+});
 
 ipcMain.on('addPNGToAST', (event: any, arg: any) => {
   fs.readFile(__dirname + '/../src/src_custom_config/png.config.js', (err, data) => {
@@ -694,10 +570,8 @@ ipcMain.on('addPNGToAST', (event: any, arg: any) => {
     });
     let customASTPropertyKey: string[] = []
     customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
-      customASTPropertyKey.push(el.key.name)
+      customASTPropertyKey.push(el.key.name);
     })
-    console.log(customASTPropertyKey);
-    //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties))
 
     if (customASTPropertyKey.indexOf(pngAST.body[0].expression.right.properties[0].key.name) === -1) {
       moduleExist = true;
@@ -707,14 +581,14 @@ ipcMain.on('addPNGToAST', (event: any, arg: any) => {
       let customASTModulePropertyKey: string[] = [];
       customAST.body[customAST.body.length - 1].expression.right.properties.forEach((el) => {
         if (el.key.name === "module") {
-          let moduleArr = el.value.properties
+          let moduleArr = el.value.properties;
           moduleArr.forEach((moduleEl) => {
             if (moduleEl.key.name === "rules") {
               moduleEl.value.elements.push(pngAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0]);
             }
-          })
+          });
         }
-      })
+      });
       moduleExist = true;
       numberOfRules += 1;
     }
@@ -723,58 +597,55 @@ ipcMain.on('addPNGToAST', (event: any, arg: any) => {
       comments: true,
     });
 
-    formattedCode1ToSave = formattedCode1
-
-    mainWindow.webContents.send('transferCustomAST', formattedCode1)
-  })
-})
+    formattedCode1ToSave = formattedCode1;
+    mainWindow.webContents.send('transferCustomAST', formattedCode1);
+  });
+});
 
 ipcMain.on('removePNGToAST', (event: any, arg: any) => {
   let module_index = 0;
   for (let i = 0; i < customAST.body[customAST.body.length - 1].expression.right.properties.length; i += 1) {
-    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i
+    if (customAST.body[customAST.body.length - 1].expression.right.properties[i].key.name === "module") module_index = i;
   }
 
   if (numberOfRules === 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
-    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1)
+    customAST.body[customAST.body.length - 1].expression.right.properties.splice(module_index, 1);
     numberOfRules -= 1;
   } else if (numberOfRules > 1 && customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties.length === 1) {
     for (let j = 0; j < customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.length; j += 1) {
       if (customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements[j].properties[0].value.raw.includes(".png")) {
-        //console.log(JSON.stringify(customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0]))
-        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1)
+        customAST.body[customAST.body.length - 1].expression.right.properties[module_index].value.properties[0].value.elements.splice(j, 1);
         numberOfRules -= 1;
       }
     }
   }
+
   const formattedCode1 = generate(customAST, {
     comments: true,
-  })
-  formattedCode1ToSave = formattedCode1
+  });
 
-  mainWindow.webContents.send('transferCustomAST', formattedCode1)
-})
+  formattedCode1ToSave = formattedCode1;
+  mainWindow.webContents.send('transferCustomAST', formattedCode1);
+});
 
 ipcMain.on('load-package.json', (event: any, arg: any) => {
   // arg unimportant. selectPackage shows file dialog
-  console.log(arg) // prints "ping"
-  event.sender.send('asynchronous-reply', 'pong')  // sends pong as test
+  event.sender.send('asynchronous-reply', 'pong');  // sends pong as test
 
   selectPackageJson();
-})
+});
 
 ipcMain.on('read-config', (event: any, configNumber: any) => {
   // after package.json is loaded configs have been sent to renderer and user
   // has now selected one and we need to load
   readConfig(configNumber);
-})
+});
 
 ipcMain.on('load-stats.json', (event: any, arg: any) => {
   // arg unimportant. User has selected to load a stats file. selectStatsJson() will present file loading dialog
-  console.log(arg) // prints "ping"
-  event.sender.send('asynchronous-reply', 'pong')
-  selectStatsJson()
-})
+  event.sender.send('asynchronous-reply', 'pong');
+  selectStatsJson();
+});
 
 ipcMain.on('loadStats2', () => {
   parseHandler.loadStats2();
@@ -782,7 +653,7 @@ ipcMain.on('loadStats2', () => {
 
 ipcMain.on('get-root-directory', () => {
   parseHandler.getRootDirectory();
-})
+});
 
 function sendRootDirectory(newDirectory: string) {
   mainWindow.webContents.send('root-Directory-Found', newDirectory);
@@ -792,16 +663,16 @@ ipcMain.on('install-pluggins', (event: any, arrPluginsChecked: string[]) => {
   var exec = require('child_process').exec;
   var child;
 
-  parseHandler.initEntryPoints()
+  parseHandler.initEntryPoints();
 
   if (arrPluginsChecked.indexOf('checkedMoment') > -1) {
-    parseHandler.loadPlugin("Moment")
+    parseHandler.loadPlugin("Moment");
   }
   if (arrPluginsChecked.indexOf('checkedSplitChunks') > -1) {
-    parseHandler.loadPlugin("SplitChunks")
+    parseHandler.loadPlugin("SplitChunks");
   }
   if (arrPluginsChecked.indexOf('checkedMini') > -1) {
-    parseHandler.loadPlugin("Mini")
+    parseHandler.loadPlugin("Mini");
   }
 
   var p1 = Promise.resolve(3);
@@ -824,7 +695,7 @@ ipcMain.on('install-pluggins', (event: any, arrPluginsChecked: string[]) => {
 });
 
 ipcMain.on('save-config', (event: any, configToSave: string) => {
-  parseHandler.saveConfig()
+  parseHandler.saveConfig();
 });
 
 ipcMain.on('does-webpack-ops-assets-exist', () => {
@@ -847,14 +718,11 @@ function callOpenModal() {
  **/
 
 function selectPackageJson() {
-  console.log("what is a dialog really?")
-  let file = dialog.showOpenDialog({ properties: ['openFile'] }) // 'openDirectory', 'multiSelections'
+  let file = dialog.showOpenDialog({ properties: ['openFile'] }); // 'openDirectory', 'multiSelections'
   if (file === undefined) {
     return false;
   }
-  // console.log("what is a file really?")
-  // console.log(file)
-  // console.log(file[0])
+
   mainWindow.webContents.send('package-is-selected');
   loadPackage(file[0]);
 }
@@ -870,7 +738,6 @@ function loadPackage(file: string) {
     directory = file.substring(0, file.lastIndexOf("\\"));
     directory2 = file.substring(0, file.lastIndexOf("\\"));
   }
-  // console.log('directory: ', directory)
 
   fs.readFile(file, (err, data) => {
     if (err) {
@@ -885,9 +752,9 @@ function loadPackage(file: string) {
 // temp store variable. This shouldn't be global, but works for the moment.
 let listOfConfigs: Array<string> = [];
 
-let entryPoints: any = {}
+let entryPoints: any = {};
 
-let ast: any = {}
+let ast: any = {};
 
 function selectConfig(packageFile: any) {
 
@@ -897,12 +764,11 @@ function selectConfig(packageFile: any) {
 
   for (let entry in entries) {
     if (entries[entry].includes('webpack')) {
-      output += `${entry} - ${entries[entry]}\n`
+      output += `${entry} - ${entries[entry]}\n`;
       listOfConfigs.push(entries[entry]);
     }
   }
-
-  mainWindow.webContents.send('choose-config', listOfConfigs)   // react should render the list in TabTwo
+  mainWindow.webContents.send('choose-config', listOfConfigs);   // react should render the list in TabTwo
 }
 
 let selectedConfig: string;
@@ -927,7 +793,7 @@ function readConfig(entry: number) {
 
   let config = "webpack.config.js";
   if (listOfConfigs[entry].includes("--config")) {
-    config = listOfConfigs[entry].split("--config")[1].trimLeft().split(" ")[0]
+    config = listOfConfigs[entry].split("--config")[1].trimLeft().split(" ")[0];
   }
 
   // console.log("loading webpack config", directory + "/" + config)
@@ -938,7 +804,7 @@ function readConfig(entry: number) {
     }
     const configFile: string = data.toString();
 
-    const tempObj = parseHandler.parseConfig(configFile, directory + "/" + config)  //configFile is the text file contents (.js) and config is the filepath
+    const tempObj = parseHandler.parseConfig(configFile, directory + "/" + config);  //configFile is the text file contents (.js) and config is the filepath
     entryPoints = tempObj.entryPoints;
     ast = tempObj.ast;
 
@@ -960,7 +826,7 @@ function readConfig(entry: number) {
  **/
 
 function selectStatsJson() {
-  let file = dialog.showOpenDialog({ properties: ['openFile'] })
+  let file = dialog.showOpenDialog({ properties: ['openFile'] });
 
   if (file === undefined) {
     return false;
@@ -970,7 +836,6 @@ function selectStatsJson() {
   mainWindow.webContents.send('stats-is-selected');
 }
 
-// fix cancel errors
 process.on('uncaughtException', function (error) {
   // Handle the error
   let err = error;
@@ -980,7 +845,6 @@ process.on('uncaughtException', function (error) {
 function loadStats(file: string) {
   fs.readFile(file, (err, data) => {
     if (err) {
-      //    alert("An error ocurred updating the file" + err.message); //alert doesn't work.
       console.log(err);
       return;
     }
@@ -995,20 +859,20 @@ function loadStats(file: string) {
     // repair brackets from split
     if (content.length > 1) {
       for (let i = 0; i < content.length; i++) {
-        content[i] = (i > 0) ? "{" : "" + content[i] + (i < content.length - 1) ? "}" : ""
+        content[i] = (i > 0) ? "{" : "" + content[i] + (i < content.length - 1) ? "}" : "";
       }
     }
 
-    content = JSON.parse(content[0])
+    content = JSON.parse(content[0]);
     while (!content.hasOwnProperty("builtAt")) {
-      content = content.children[0]
+      content = content.children[0];
     }
     let returnObj: any = {};
     returnObj.timeStamp = Date.now();
     returnObj.time = content.time;
     returnObj.hash = content.hash;
-    returnObj.errors = content.errors
-    returnObj.size = content.assets.reduce((size: number, asset: any): void => size + asset.size, 0)
+    returnObj.errors = content.errors;
+    returnObj.size = content.assets.reduce((size: number, asset: any): void => size + asset.size, 0);
     returnObj.assets = content.assets.map((asset: any) => ({
       name: asset.name,
       chunks: asset.chunks,
@@ -1027,8 +891,8 @@ function loadStats(file: string) {
         : [],
     }));
 
-    let Pdata: any = []
-    Pdata.push(returnObj)
+    let Pdata: any = [];
+    Pdata.push(returnObj);
     //loops through assets
     let i = 0; // or the latest build
     let path: string;
@@ -1040,26 +904,19 @@ function loadStats(file: string) {
       for (var l = 0; l < Pdata[i].chunks[k].modules.length; l++) {
         sizeStr = Pdata[i].chunks[k].modules[l].size.toString();
         path = Pdata[i].chunks[k].modules[l].name.replace("./", "");
-        sunBurstData.push([path, sizeStr])
+        sunBurstData.push([path, sizeStr]);
       }
     }
     const sunBurstDataSum: number = sunBurstData.reduce((sum: number, el: any): number => {
-      return sum += parseInt(el[1])
-    }, 0)
+      return sum += parseInt(el[1]);
+    }, 0);
 
     const returnObjData = {
       chunks: returnObj.chunks,
       assets: returnObj.assets
     }
 
-    // sunBurstData.push(returnObj);
-    // console.log(sunBurstDataSum)
-    //console.log(co)
-    // console.log(content.substring(0, 40))
-    mainWindow.webContents.send('display-stats-reply', sunBurstData, returnObjData)
-
-    //mainWindow.webContents.send('display-stats-reply', JSON.parse(content))
-
+    mainWindow.webContents.send('display-stats-reply', sunBurstData, returnObjData);
   });
 }
 
@@ -1073,7 +930,6 @@ export default function loadNewStats(file: string, newWebpackConfigFile?: string
 
   fs.readFile(file, (err, data) => {
     if (err) {
-      //    alert("An error ocurred updating the file" + err.message); //alert doesn't work.
       console.log(err);
       return;
     }
@@ -1088,20 +944,20 @@ export default function loadNewStats(file: string, newWebpackConfigFile?: string
     // repair brackets from split
     if (content.length > 1) {
       for (let i = 0; i < content.length; i++) {
-        content[i] = (i > 0) ? "{" : "" + content[i] + (i < content.length - 1) ? "}" : ""
+        content[i] = (i > 0) ? "{" : "" + content[i] + (i < content.length - 1) ? "}" : "";
       }
     }
 
-    content = JSON.parse(content[0])
+    content = JSON.parse(content[0]);
     while (!content.hasOwnProperty("builtAt")) {
-      content = content.children[0]
+      content = content.children[0];
     }
     let returnObj: any = {};
     returnObj.timeStamp = Date.now();
     returnObj.time = content.time;
     returnObj.hash = content.hash;
-    returnObj.errors = content.errors
-    returnObj.size = content.assets.reduce((size: number, asset: any): void => size + asset.size, 0)
+    returnObj.errors = content.errors;
+    returnObj.size = content.assets.reduce((size: number, asset: any): void => size + asset.size, 0);
     returnObj.assets = content.assets.map((asset: any) => ({
       name: asset.name,
       chunks: asset.chunks,
@@ -1120,25 +976,24 @@ export default function loadNewStats(file: string, newWebpackConfigFile?: string
         : [],
     }));
 
-    let Pdata: any = []
-    Pdata.push(returnObj)
+    let Pdata: any = [];
+    Pdata.push(returnObj);
     //loops through assets
     let i = 0; // or the latest build
     let path: string;
     let sizeStr: string;
     let sunBurstData = [];
 
-
     for (var k = 0; k < Pdata[i].chunks.length; k++) {
       for (var l = 0; l < Pdata[i].chunks[k].modules.length; l++) {
         sizeStr = Pdata[i].chunks[k].modules[l].size.toString();
         path = Pdata[i].chunks[k].modules[l].name.replace("./", "");
-        sunBurstData.push([path, sizeStr])
+        sunBurstData.push([path, sizeStr]);
       }
     }
     const sunBurstDataSum: number = sunBurstData.reduce((sum: number, el: any): number => {
-      return sum += parseInt(el[1])
-    }, 0)
+      return sum += parseInt(el[1]);
+    }, 0);
 
     const returnObjData = {
       chunks: returnObj.chunks,
@@ -1157,7 +1012,7 @@ export default function loadNewStats(file: string, newWebpackConfigFile?: string
     fs.rename(file, newFile, (err) => {
       if (err) {
         throw (err);
-        console.log(err)
+        console.log(err);
       } else {
         return;
       }
@@ -1169,7 +1024,7 @@ export default function loadNewStats(file: string, newWebpackConfigFile?: string
     fs.rename(newWebpackConfigFile, newPathWebpackFile, (err) => {
       if (err) {
         throw (err);
-        console.log(err)
+        console.log(err);
       } else {
         return;
       }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -827,6 +827,17 @@ ipcMain.on('save-config', (event: any, configToSave: string) => {
   parseHandler.saveConfig()
 });
 
+ipcMain.on('does-webpack-ops-assets-exist', () => {
+  parseHandler.doesWebpackOpsAssetsExist();
+});
+
+function callInstallPluggins() {
+  mainWindow.webContents.send('call-install-pluggins');
+}
+
+function callOpenModal() {
+  mainWindow.webContents.send('webpack-ops-assets-does-not-exist');
+}
 
 /**
  * Event handlers - file loading / parsing
@@ -1166,4 +1177,4 @@ export default function loadNewStats(file: string, newWebpackConfigFile?: string
   });
 }
 
-export { ogStatsGenerated, sendRootDirectory };
+export { ogStatsGenerated, sendRootDirectory, callInstallPluggins, callOpenModal };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -71,9 +71,6 @@ ipcMain.on('saveCustomConfig', (event: any, rootDirectoryCustomConfig: string) =
       console.log(err);
       return;
     }
-
-    console.log("The new file has been succesfully saved as");
-
   });
 })
 
@@ -685,7 +682,7 @@ ipcMain.on('install-pluggins', (event: any, arrPluginsChecked: string[]) => {
 
   Promise.all([p1, p2, p3])
     .then(values => {
-      console.log(values); // [3, 1337, "foo"]
+      //console.log(values); // [3, 1337, "foo"]
 
       setTimeout(() => {
         mainWindow.webContents.send('display-config', parseHandler.updatedConfig);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -149,7 +149,7 @@ ipcMain.on('addReactToAST', (event: any, arg: any) => {
     //console.log(customASTPropertyKey);
 
     if (numberOfRules === 0) {
-      customAST.body[customAST.body.length - 1].expression.right.properties.push(ReactAST.body[0].expression.right.properties[0])
+      customAST.body[customAST.body.length - 1].expression.right.properties.push(ReactAST.body[0].expression.right.properties[0]);
       moduleExist = true;
       numberOfRules += 1;
     } else {
@@ -169,7 +169,7 @@ ipcMain.on('addReactToAST', (event: any, arg: any) => {
               moduleEl.value.elements.unshift(ReactAST.body[0].expression.right.properties[0].value.properties[0].value.elements[0])
               console.log(JSON.stringify(moduleEl.value.elements))
             }
-          })
+          });
         }
       })
       moduleExist = true;

--- a/src/main/parseHandler.ts
+++ b/src/main/parseHandler.ts
@@ -238,10 +238,6 @@ const parseHandler: ParseHandler = {
   },
 
   doesWebpackOpsAssetsExist: function () {
-    // let archiveName: string = this.configFile.split(".js")[0] + ".bak" + ".js";
-    // fs.rename(this.directory + this.configFile, this.directory + archiveName, (err) => {
-    //   if (err) throw err;
-    // });
 
     // check if WebpackOpsAssets directory exists. if so, call installPluggins in TabTwo
     if (fs.existsSync(this.directory + '/WebpackOpsAssets')) {
@@ -344,8 +340,6 @@ const parseHandler: ParseHandler = {
         }
       });
     }
-
-    // if (newConfig) console.log('newWebpackConfigFile: ', newWebpackConfigFile)
   },
 
   loadPlugin: function (name) {
@@ -362,7 +356,7 @@ const parseHandler: ParseHandler = {
     }
     fs.readFile(__dirname + '/../src/plugins/' + pluginFileName, (err, data) => {
       if (err) return console.log(err)
-      this.parsePlugin(data.toString())
+      this.parsePlugin(data.toString());
       return { entryPoints: pluginEntryPoints }
     });
   },
@@ -374,17 +368,17 @@ const parseHandler: ParseHandler = {
       ecmaVersion: 6,
       locations: true,
       onComment: comments,
-    })
+    });
 
     // Attach comments to AST nodes
-    astravel.attachComments(ast, comments)
+    astravel.attachComments(ast, comments);
 
     pluginEntryPoints.all = ast;
     pluginEntryPoints.body = ast.body;
 
-    let i = ast.body.length - 1 // Checking for module.exports from the end. Should be the last node.
-    let configs: any = []
-    let oldModuleExports: any
+    let i = ast.body.length - 1; // Checking for module.exports from the end. Should be the last node.
+    let configs: any = [];
+    let oldModuleExports: any;
 
     // loop through ast looking for module.exports
     while (i >= 0) {
@@ -400,15 +394,15 @@ const parseHandler: ParseHandler = {
     }
 
     if (oldModuleExports.type === "ObjectExpression") {
-      configs.push(oldModuleExports)
-      pluginEntryPoints.moduleExports = oldModuleExports
+      configs.push(oldModuleExports);
+      pluginEntryPoints.moduleExports = oldModuleExports;
     }
 
-    pluginEntryPoints.pluginsSection = pluginEntryPoints.moduleExports.properties.filter(element => element.key.name === "plugins")[0]
+    pluginEntryPoints.pluginsSection = pluginEntryPoints.moduleExports.properties.filter(element => element.key.name === "plugins")[0];
 
-    pluginEntryPoints.optimizationSection = pluginEntryPoints.moduleExports.properties.filter(element => element.key.name === "optimization")[0]
+    pluginEntryPoints.optimizationSection = pluginEntryPoints.moduleExports.properties.filter(element => element.key.name === "optimization")[0];
 
-    this.mergePlugin()
+    this.mergePlugin();
 
     return { pluginEntryPoints, ast }
   },
@@ -431,20 +425,18 @@ const parseHandler: ParseHandler = {
         // only add const webpack = require('webpack') if doesn't already exist
         entryPoints.body.unshift(pluginEntryPoints.body[0]);
       }
-      // entryPoints.body.unshift(pluginEntryPoints.body[0])  // should check to see if already exists 
-      // and do all variable definitions. currently doing one.
     }
     // Add any plugins to the plugins section of the config
     if (pluginEntryPoints.pluginsSection && pluginEntryPoints.pluginsSection.value.elements.length !== 0) {
       // check to see if plugins section of config exists and add if needed
       if (!entryPoints.pluginsSection) {
         // check to see if there is a plugins section already in place  
-        entryPoints.moduleExports.properties.push(pluginEntryPoints.pluginsSection)
+        entryPoints.moduleExports.properties.push(pluginEntryPoints.pluginsSection);
       } else {
         pluginEntryPoints.pluginsSection.value.elements.forEach(element => {
           entryPoints.pluginsSection.value.elements
-            .push(JSON.parse(JSON.stringify(element)))
-        })
+            .push(JSON.parse(JSON.stringify(element)));
+        });
       }
     }
     // Add any optimizations to the optimizations section of the config
@@ -452,17 +444,17 @@ const parseHandler: ParseHandler = {
       // check to see if optimization section of config exists and add if needed
       if (!entryPoints.optimizationSection) {
         // check to see if there is an optimization section already in place  
-        entryPoints.moduleExports.properties.push(pluginEntryPoints.optimizationSection)
+        entryPoints.moduleExports.properties.push(pluginEntryPoints.optimizationSection);
       } else {
         pluginEntryPoints.optimizationSection.value.properties.forEach(element => {
           if (!entryPoints.optimizationSection.value.properties[0]) {
             entryPoints.optimizationSection.value.properties
-              .push(JSON.parse(JSON.stringify(element)))
+              .push(JSON.parse(JSON.stringify(element)));
           }
         });
       }
     }
-    this.updateConfig()
+    this.updateConfig();
   },
 }
 

--- a/src/plugins/momentLocalsPluginConfig.js
+++ b/src/plugins/momentLocalsPluginConfig.js
@@ -1,8 +1,0 @@
-// const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
-
-// module.exports = {
-//     plugins: [
-//         // To strip all locales except “en”
-//         new MomentLocalesPlugin(),
-//     ],
-// };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,8 +6,8 @@ import Home from './components/Home';
 import { FaHome } from "react-icons/fa";
 import { FaCube } from "react-icons/fa";
 import { IoLogoBuffer } from "react-icons/io";
-import { observer, inject } from 'mobx-react'
-import { StoreType } from './store'
+import { observer, inject } from 'mobx-react';
+import { StoreType } from './store';
 
 // Import the styles here to process them with webpack
 import './styles.scss';

--- a/src/renderer/components/Home.tsx
+++ b/src/renderer/components/Home.tsx
@@ -9,6 +9,7 @@ import WhiteCardPackageJSON from './WhiteCardPackageJSON';
 import WhiteCardWebpackConfig from './WhiteCardWebpackConfig';
 import WhiteCardStatsJSON from './WhiteCardStatsJSON';
 import D3ChartContainerCard from './D3ChartContainerCard';
+import ModalHome from './ModalHome';
 
 type Props = {
   store?: StoreType
@@ -24,6 +25,7 @@ const initialState = {
   totalNodeCount: 0,
   totalAssets: 0,
   totalChunks: 0,
+  isModalDisplayed: false,
   data: {
     "name": "A1",
     "children": [
@@ -76,6 +78,12 @@ type StateType = Readonly<typeof initialState>
 export default class Home extends React.Component<Props, StateType> {
   // may need "readonly"
   state: StateType = initialState;
+
+  constructor(props) {
+    super(props);
+    this.handleShowModal = this.handleShowModal.bind(this);
+    this.handleCloseModal = this.handleCloseModal.bind(this);
+  }
 
   componentDidMount() {
     ipcRenderer.on('display-stats-reply', (event: any, data: string[][], obj: any): void => {
@@ -933,15 +941,34 @@ export default class Home extends React.Component<Props, StateType> {
   getWebpackConfig = (event: any): void => {
     let radios = document.getElementsByName("config"); // as HTMLInputElement
 
+    let configSelected: boolean = false;
     for (var i = 0, length = radios.length; i < length; i++) {
       if ((radios[i] as HTMLInputElement).checked) {
         // send the checked radio
         ipcRenderer.send('read-config', i);
+        configSelected = true;
         break;
       }
     }
+
+    // if no config selected, show modal informing user that they must select config
+    if (!configSelected) {
+      this.handleShowModal();
+    }
+
     event.preventDefault();
-    this.doSetDisplayConfigSelectionFalse();
+
+    if (configSelected) {
+      this.doSetDisplayConfigSelectionFalse();
+    }
+  }
+
+  handleShowModal = () => {
+    this.setState({ isModalDisplayed: true });
+  }
+
+  handleCloseModal = () => {
+    this.setState({ isModalDisplayed: false });
   }
 
   getWebpackStats = (): void => {
@@ -1007,6 +1034,15 @@ export default class Home extends React.Component<Props, StateType> {
             listOfConfigs={this.state.listOfConfigs}
           />
         }
+
+        {this.state.isModalDisplayed ? (
+          <ModalHome
+            onClose={this.handleCloseModal}
+            isModalDisplayed={this.state.isModalDisplayed}
+          >
+            Attention:
+            </ModalHome>
+        ) : null}
 
         {store.isPackageSelected && !this.props.store.isConfigSelectionDisplayed && this.props.store.isLoadStatsDisplayed &&
 

--- a/src/renderer/components/Home.tsx
+++ b/src/renderer/components/Home.tsx
@@ -227,12 +227,12 @@ export default class Home extends React.Component<Props, StateType> {
 
     let color = function () {
       let ctr = 0;
-      const hex = ['#8cc4d9', '#64b0cc', '#409dbf', '#337e99', '#265e73', '#193f4d']
-      // const hex = ['#cbedef', '#b6e7ed', '#9befee', '#d3e6e8', '#7df2ec', '#cdf2e4']
+      const hex = ['#8cc4d9', '#64b0cc', '#409dbf', '#337e99', '#265e73', '#193f4d'];
+
       return function () {
         if (ctr === hex.length - 1) {
           ctr = 0;
-          return hex[ctr]
+          return hex[ctr];
         } else {
           ctr++;
           return hex[ctr];
@@ -268,6 +268,7 @@ export default class Home extends React.Component<Props, StateType> {
 
       d3.select("#percentage")
         .text('% of Total: ' + percentageString);
+
       //ADDED FILE NAME
       d3.select("#filename")
         .text(d.data.name);
@@ -529,7 +530,7 @@ export default class Home extends React.Component<Props, StateType> {
     const slice = svg.selectAll('g.slice').data(partition(root).descendants());
 
     slice.exit().remove();
-    let path1 = d3.selectAll('g').data(root.descendants())
+    let path1 = d3.selectAll('g').data(root.descendants());
     let totalSize = path1.datum().value;
 
     const newSlice = slice

--- a/src/renderer/components/Modal.tsx
+++ b/src/renderer/components/Modal.tsx
@@ -17,7 +17,7 @@ function Modal(props: ModalProps) {
       style={{
         position: 'absolute',
         top: '0',
-        bottom: '0', ////////
+        bottom: '0',
         left: '0',
         right: '0',
         display: 'grid',

--- a/src/renderer/components/ModalHome.tsx
+++ b/src/renderer/components/ModalHome.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import Button from './Button';
+
+interface ModalHomeProps {
+  onClose(): void;
+  children: string;
+  isModalDisplayed: boolean;
+}
+
+function ModalHome(props: ModalHomeProps) {
+  return ReactDOM.createPortal(
+    <div
+      style={{
+        position: 'absolute',
+        top: '0',
+        bottom: '0',
+        left: '0',
+        right: '0',
+        display: 'grid',
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: 'rgba(0,0,0,0.3)',
+        animation: 'whiteCardFadeIn 0.6s',
+      }}
+      onClick={props.onClose}
+    >
+      <div
+        style={{
+          padding: 20,
+          background: 'rgba(252, 252, 252, 1)',
+          borderRadius: '2px',
+          display: 'inline-block',
+          minHeight: '175px',
+          margin: '1rem',
+          position: 'relative',
+          minWidth: '575px',
+          maxWidth: '575px',
+          boxShadow: '0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23)',
+          justifySelf: 'center',
+          fontSize: '30px',
+          marginBottom: '10px',
+          color: '#485563',
+          fontFamily: "'Oswald', 'sans-serif'",
+          paddingLeft: '25px',
+          animation: 'whiteCardFadeIn 0.6s',
+        }}
+      >
+        {props.children}
+        <hr />
+        <div className="tabTwoDescriptionTextModal">
+          <div className="modalText">No <span className="codeTextStatsHome">webpack.config</span> selected. Please select a config file to continue.</div>
+          <br></br>
+
+        </div>
+        <div className="modalButtonContainer">
+          <Button
+            classes="btnModalContinue stats"
+            idName="tabTwoStatsButton"
+            func={props.onClose}
+            textContent="Close"
+          />
+
+        </div>
+      </div>
+    </div >,
+    document.querySelector("#modal"));
+}
+
+export default ModalHome;

--- a/src/renderer/components/TabThree.tsx
+++ b/src/renderer/components/TabThree.tsx
@@ -31,15 +31,22 @@ type StateType = Readonly<typeof initialState>
 
 export default class TabThree extends React.Component<Props, StateType> {
   state: StateType = initialState;
+  _isMounted: boolean = false;
 
   componentDidMount() {
+    this._isMounted = true;
+
     ipcRenderer.on('customRootDirectrySet', (event: any, customDirectory: string): void => {
-      this.setState({ rootCustomDirectory: customDirectory });
+      if (this._isMounted) {
+        this.setState({ rootCustomDirectory: customDirectory });
+      }
     });
 
     ipcRenderer.send('CustomAST', 'ping');
     ipcRenderer.on('transferCustomAST', (event: any, formattedCode1: string): void => {
-      this.setState({ defaultFormattedCode: formattedCode1 });
+      if (this._isMounted) {
+        this.setState({ defaultFormattedCode: formattedCode1 });
+      }
     });
 
     ipcRenderer.on('root-is-selected', (): void => {
@@ -51,35 +58,45 @@ export default class TabThree extends React.Component<Props, StateType> {
     if (this.state.checkedReact === false) ipcRenderer.send('addReactToAST');
     else ipcRenderer.send('removeReactToAST');
 
-    this.setState({ checkedReact: !this.state.checkedReact });
+    if (this._isMounted) {
+      this.setState({ checkedReact: !this.state.checkedReact });
+    }
   }
 
   handleChangeCheckboxCSS = (event: any): void => {
     if (this.state.checkedCSS === false) ipcRenderer.send('addCSSToAST');
     else ipcRenderer.send('removeCSSToAST');
 
-    this.setState({ checkedCSS: !this.state.checkedCSS });
+    if (this._isMounted) {
+      this.setState({ checkedCSS: !this.state.checkedCSS });
+    }
   }
 
   handleChangeCheckboxSass = (event: any): void => {
     if (this.state.checkedSass === false) ipcRenderer.send('addSassToAST');
     else ipcRenderer.send('removeSassToAST');
 
-    this.setState({ checkedSass: !this.state.checkedSass });
+    if (this._isMounted) {
+      this.setState({ checkedSass: !this.state.checkedSass });
+    }
   }
 
   handleChangeCheckboxLess = (event: any): void => {
     if (this.state.checkedLess === false) ipcRenderer.send('addLessToAST');
     else ipcRenderer.send('removeLessToAST');
 
-    this.setState({ checkedLess: !this.state.checkedLess });
+    if (this._isMounted) {
+      this.setState({ checkedLess: !this.state.checkedLess });
+    }
   }
 
   handleChangeCheckboxStylus = (event: any): void => {
     if (this.state.checkedStylus === false) ipcRenderer.send('addStylusToAST');
     else ipcRenderer.send('removeStylusToAST');
 
-    this.setState({ checkedStylus: !this.state.checkedStylus });
+    if (this._isMounted) {
+      this.setState({ checkedStylus: !this.state.checkedStylus });
+    }
   }
 
   handleChangeCheckboxSVG = (event: any): void => {
@@ -87,14 +104,18 @@ export default class TabThree extends React.Component<Props, StateType> {
     if (this.state.checkedSVG === false) ipcRenderer.send('addSVGToAST');
     else ipcRenderer.send('removeSVGToAST');
 
-    this.setState({ checkedSVG: !this.state.checkedSVG });
+    if (this._isMounted) {
+      this.setState({ checkedSVG: !this.state.checkedSVG });
+    }
   }
 
   handleChangeCheckboxPNG = (event: any): void => {
     if (this.state.checkedPNG === false) ipcRenderer.send('addPNGToAST');
     else ipcRenderer.send('removePNGToAST');
 
-    this.setState({ checkedPNG: !this.state.checkedPNG });
+    if (this._isMounted) {
+      this.setState({ checkedPNG: !this.state.checkedPNG });
+    }
   }
 
   doSetRootSelected = (): void => {
@@ -113,6 +134,10 @@ export default class TabThree extends React.Component<Props, StateType> {
 
   doSetCustomConfigSaved(): void {
     this.props.store.setCustomConfigSavedTrue()
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   render() {

--- a/src/renderer/components/TabTwo.tsx
+++ b/src/renderer/components/TabTwo.tsx
@@ -51,7 +51,7 @@ export default class TabTwo extends React.Component<Props, StateType> {
 
     // Added for displaying webpack config
     ipcRenderer.on('display-config', (event: any, data: any): void => {
-      console.log("display updated config")
+      
       this.doSetNewConfigDisplayCode(data);
       if (this._isMounted) {
         this.setState({ value: data });
@@ -59,14 +59,14 @@ export default class TabTwo extends React.Component<Props, StateType> {
     });
 
     ipcRenderer.on('set-new-stats', (event: any, data: number): void => {
-      console.log('data: ', data);
+      
       this.doSetNewTotalSize(data);
       if (this._isMounted) {
         this.setState({
           newTotalSize: data
         }, () => this.doSetIsBuildOptimized());
       }
-    })
+    });
   }
 
   doSetNewTotalSize = (newSize: number): void => {
@@ -122,11 +122,11 @@ export default class TabTwo extends React.Component<Props, StateType> {
     ipcRenderer.send('get-root-directory');
 
     ipcRenderer.on('root-Directory-Found', (event: any, rootDirectory: string): void => {
-      console.log('data: ', rootDirectory);
+      
       if (this._isMounted) {
         this.setState({ rootDirectory });
       }
-    })
+    });
   }
 
   installPluggins = (): void => {
@@ -135,7 +135,7 @@ export default class TabTwo extends React.Component<Props, StateType> {
       // console.log(el)
       if (this.state[el] === true) accum.push(el);
       return accum;
-    }, [])
+    }, []);
 
     ipcRenderer.send('install-pluggins', arrToInstall);
     this.doSetIsNewConfigGenerated();

--- a/src/renderer/components/TabTwo.tsx
+++ b/src/renderer/components/TabTwo.tsx
@@ -187,20 +187,19 @@ export default class TabTwo extends React.Component<Props, StateType> {
   handleShowModal = () => {
     this.getRootDirectory();
 
-    // if WebpackOpsAssets folder doesn't already exist, then open modal
     ipcRenderer.send('does-webpack-ops-assets-exist');
 
+    // if WebpackOpsAssets folder doesn't already exist, then open modal
     ipcRenderer.on('webpack-ops-assets-does-not-exist', () => {
-      // otherwise, call installPluggins from here
       if (this._isMounted) {
         this.setState({ isModalDisplayed: true });
       }
     });
 
+    // otherwise, call installPluggins from here
     ipcRenderer.on('call-install-pluggins', () => {
-      console.log('calling here!!!!')
       this.installPluggins();
-    })
+    });
   }
 
   handleCloseModal = () => {

--- a/src/renderer/components/WhiteCardTabTwoMain.tsx
+++ b/src/renderer/components/WhiteCardTabTwoMain.tsx
@@ -4,6 +4,7 @@ import SyntaxHighlighter from 'react-syntax-highlighter';
 import { paraisoLight } from 'react-syntax-highlighter/dist/styles/hljs';
 import Spinner from './AwesomeComponent';
 import Modal from './Modal';
+import { FaCheck } from "react-icons/fa";
 
 interface WhiteCardTabTwoMainProps {
   handleChangeCheckboxSplitChunks(event: any): void;
@@ -91,6 +92,15 @@ const WhiteCardTabTwoMain = (props: WhiteCardTabTwoMainProps) => {
               textContent="Show Size Change"
             />
           }
+
+          {props.isNewBuildSizeCalculated &&
+            <div className="tabThreeRowFlexContainer">
+              < FaCheck className="greenCheck" />
+              <div id="webpackConfigSaveText">
+                webpack.config.js generated
+              </div>
+            </div>}
+
         </div>
       }
       <div id="configbox"></div>

--- a/src/renderer/components/WhiteCardWelcome.unit.test.tsx
+++ b/src/renderer/components/WhiteCardWelcome.unit.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow , mount} from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import WhiteCardWelcome from './WhiteCardWelcome';
 
 
@@ -7,9 +7,9 @@ import WhiteCardWelcome from './WhiteCardWelcome';
 // isPackageSelected: boolean;
 describe('<WhiteCardWelcome />', () => {
   it('allows us to set props', () => {
-    const wrapper = mount(<WhiteCardWelcome displayWelcomeCard={true} isPackageSelected={false} />);
-    expect(wrapper.props().displayWelcomeCard).toEqual(true);
-    wrapper.setProps({ displayWelcomeCard: false });
-    expect(wrapper.props().displayWelcomeCard).toEqual(false);
+    const wrapper = mount(<WhiteCardWelcome isWelcomeCardDisplayed={true} isPackageSelected={false} />);
+    expect(wrapper.props().isWelcomeCardDisplayed).toEqual(true);
+    wrapper.setProps({ isWelcomeCardDisplayed: false });
+    expect(wrapper.props().isWelcomeCardDisplayed).toEqual(false);
   });
 });

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import App from './App'
+import App from './App';
 import { Provider } from 'mobx-react';
-import Store from './store'
+import Store from './store';
 import './styles.scss';
 import { ipcRenderer } from 'electron';
 

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -1,4 +1,4 @@
-import { observable, action } from 'mobx'
+import { observable, action } from 'mobx';
 import { initializeInstance } from 'mobx/lib/internal';
 
 export type StoreType = {
@@ -459,4 +459,3 @@ export default class Store {
 		this.isOriginalStatsGenerated = true;
 	}
 }
-

--- a/src/renderer/styles.scss
+++ b/src/renderer/styles.scss
@@ -820,7 +820,6 @@ pre {
   font-family: 'Monaco';
   font-size: 12px;
   word-wrap: break-word;
-  // padding-left: 0;
   margin-left: -21px;
 }
 

--- a/src/renderer/styles.scss
+++ b/src/renderer/styles.scss
@@ -839,6 +839,10 @@ pre {
   font-size: 20px;
 }
 
+.codeTextStatsHome {
+  color: $text-primary;
+}
+
 .codeTextStatsTabThree {
   color: $text-primary;
 }


### PR DESCRIPTION
- Update to save new webpack.config and stats.json files to have current date/time at beginning of file names so files aren't overwritten on every build, all previous builds are now saved in 'WebpackOpsAssets' directory
- Add conditional checks in Tab2//main//parseHandler so Modal doesn’t pop up if ‘WebpackOpsAssets’ folder already exists in client’s root directory
- Fix memory leak Warning on Tab2//Tab3 by implementing _isMounted pattern in componentWillUnmount
- Add ModalHome component that will display if no webpack.config file selected on Home
- Remove unnecessary console.logs throughout project
- Add 'webpack.config.js generated' message and green check on Tab2 when new config files have been generated in WebpackOpsAssets directory